### PR TITLE
金額計算の処理を実装し、それに合わせて状態保持する場所をEditNumberFieldからTipTimeScreenに変更

### DIFF
--- a/app/src/main/java/com/example/tiptime/MainActivity.kt
+++ b/app/src/main/java/com/example/tiptime/MainActivity.kt
@@ -6,11 +6,9 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import com.example.tiptime.ui.theme.TipTimeTheme
+import java.text.NumberFormat
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -22,9 +20,20 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    TipTimeScreen()
+                    TipTimeScreen(::calculateTip)
                 }
             }
         }
+    }
+
+    /**
+     * チップの計算
+     */
+    private fun calculateTip(
+        amount: Double,
+        tipPercent: Double = 15.0
+    ):String {
+        val tip = tipPercent / 100 * amount
+        return NumberFormat.getCurrencyInstance().format(tip)
     }
 }

--- a/app/src/main/java/com/example/tiptime/TipTimeScreen.kt
+++ b/app/src/main/java/com/example/tiptime/TipTimeScreen.kt
@@ -27,49 +27,61 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.tiptime.ui.theme.TipTimeTheme
+import java.text.NumberFormat
 
 @Composable
-fun TipTimeScreen() {
+fun TipTimeScreen(calculateTip: (Double) -> String) {
     Column(
         modifier = Modifier.padding(32.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
+        var amountInput by remember { mutableStateOf("") }
+
+        // StringからDoubleに型変換
+        val amount = amountInput.toDoubleOrNull() ?: 0.0
+        // 計算実行した結果を変数に格納
+        val tip = calculateTip.invoke(amount)
+
         Text(
             text = stringResource(id = R.string.calculate_tip),
             fontSize = 24.sp,
             modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Spacer(Modifier.height(16.dp))
-        EditNumberField()
-
+        EditNumberField(
+            value = amountInput,
+            onValueChange = { amountInput = it }
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = stringResource(id = R.string.tip_amount, tip),
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        )
     }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun EditNumberField() {
-    var amountInput by remember { mutableStateOf("") }
+fun EditNumberField(
+    value: String,
+    onValueChange: (String) -> Unit
+) {
     TextField(
-        value = amountInput,
-        onValueChange = { amountInput = it },
+        value = value,
+        onValueChange = onValueChange,
         label = { Text(stringResource(R.string.cost_of_service)) },
         modifier = Modifier.fillMaxWidth(),
         singleLine = true,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
     )
-    Spacer(modifier = Modifier.height(24.dp))
-    Text(
-        text = stringResource(id = R.string.tip_amount, ""),
-        fontSize = 20.sp,
-        fontWeight = FontWeight.Bold
-        )
 }
-
 
 @Preview(showBackground = true)
 @Composable
 fun DefaultPreview() {
     TipTimeTheme {
-        TipTimeScreen()
+        TipTimeScreen {_ -> "$15.00"}
     }
 }


### PR DESCRIPTION
## チケットへのリンク

* https://developer.android.com/codelabs/basic-android-kotlin-compose-using-state?hl=ja&continue=https%3A%2F%2Fdeveloper.android.com%2Fcourses%2Fpathways%2Fandroid-basics-compose-unit-2-pathway-3%3Fhl%3Dja%23codelab-https%3A%2F%2Fdeveloper.android.com%2Fcodelabs%2Fbasic-android-kotlin-compose-using-state#11

## 対応内容

* 金額計算の処理を実装
* amountInput の状態を EditNumberField() コンポーザブルから TipTimeScreen() コンポーザブルにホイスティングし、EditNumberField() コンポーザブルをステートレスに変更した


## レビュー観点

* 実装に違和感ないか


## 期待動作

* 入力値に則したチップの計算ができること

## スクリーンショット

| before | after |
|--------|-------|
|<img src="" width="200px"/>|<img src="https://github.com/yanPWA/TipTime/assets/82929509/6b489bce-b286-4861-8e43-7a821cbca11c" width="200px"/>|

