### PR TITLE
チップの切り上げ処理を実装

### DIFF
--- a/app/src/main/java/com/example/tiptime/MainActivity.kt
+++ b/app/src/main/java/com/example/tiptime/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import com.example.tiptime.ui.theme.TipTimeTheme
 import java.text.NumberFormat
+import kotlin.math.ceil
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -31,9 +32,12 @@ class MainActivity : ComponentActivity() {
      */
     private fun calculateTip(
         amount: Double,
-        tipPercent: Double = 15.0
-    ):String {
-        val tip = tipPercent / 100 * amount
+        tipPercent: Double = 15.0,
+        roundUp: Boolean
+    ): String {
+        var tip = tipPercent / 100 * amount
+        // 切り上げスイッチがtrueの場合は計算結果を切り上げ表示する
+        if (roundUp) tip = ceil(tip)
         return NumberFormat.getCurrencyInstance().format(tip)
     }
 }

--- a/app/src/main/java/com/example/tiptime/TipTimeScreen.kt
+++ b/app/src/main/java/com/example/tiptime/TipTimeScreen.kt
@@ -1,12 +1,14 @@
 package com.example.tiptime
 
-import android.annotation.SuppressLint
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -14,34 +16,39 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.tiptime.ui.theme.TipTimeTheme
-import java.text.NumberFormat
 
 @Composable
-fun TipTimeScreen(calculateTip: (Double) -> String) {
+fun TipTimeScreen(calculateTip: (Double, Double) -> String) {
+    var amountInput by remember { mutableStateOf("") }
+    var tipInput by remember { mutableStateOf("") }
+
+    // StringからDoubleに型変換
+    val amount = amountInput.toDoubleOrNull() ?: 0.0
+    val tipPercent = tipInput.toDoubleOrNull() ?: 0.0
+    // 計算実行した結果を変数に格納
+    val tip = calculateTip.invoke(amount, tipPercent)
+
+    val focusManager = LocalFocusManager.current
+
     Column(
         modifier = Modifier.padding(32.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        var amountInput by remember { mutableStateOf("") }
-
-        // StringからDoubleに型変換
-        val amount = amountInput.toDoubleOrNull() ?: 0.0
-        // 計算実行した結果を変数に格納
-        val tip = calculateTip.invoke(amount)
-
         Text(
             text = stringResource(id = R.string.calculate_tip),
             fontSize = 24.sp,
@@ -49,8 +56,24 @@ fun TipTimeScreen(calculateTip: (Double) -> String) {
         )
         Spacer(Modifier.height(16.dp))
         EditNumberField(
+            label = R.string.bill_amount,
+            keyboardOptions = KeyboardOptions.Default.copy(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Next
+            ),
+            keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
             value = amountInput,
             onValueChange = { amountInput = it }
+        )
+        EditNumberField(
+            label = R.string.how_was_the_service,
+            keyboardOptions = KeyboardOptions.Default.copy(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+            value = tipInput,
+            onValueChange = { tipInput = it }
         )
         Spacer(modifier = Modifier.height(24.dp))
         Text(
@@ -62,19 +85,27 @@ fun TipTimeScreen(calculateTip: (Double) -> String) {
     }
 }
 
+/**
+ * チップの計算
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditNumberField(
+    @StringRes label: Int,
+    keyboardOptions: KeyboardOptions,
+    keyboardActions: KeyboardActions,
     value: String,
-    onValueChange: (String) -> Unit
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     TextField(
         value = value,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
         onValueChange = onValueChange,
-        label = { Text(stringResource(R.string.cost_of_service)) },
+        label = { Text(stringResource(label)) },
         modifier = Modifier.fillMaxWidth(),
         singleLine = true,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
     )
 }
 
@@ -82,6 +113,6 @@ fun EditNumberField(
 @Composable
 fun DefaultPreview() {
     TipTimeTheme {
-        TipTimeScreen {_ -> "$15.00"}
+        TipTimeScreen { _, _ -> "$15.00" }
     }
 }

--- a/app/src/main/java/com/example/tiptime/TipTimeScreen.kt
+++ b/app/src/main/java/com/example/tiptime/TipTimeScreen.kt
@@ -8,9 +8,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -21,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -33,15 +38,16 @@ import androidx.compose.ui.unit.sp
 import com.example.tiptime.ui.theme.TipTimeTheme
 
 @Composable
-fun TipTimeScreen(calculateTip: (Double, Double) -> String) {
+fun TipTimeScreen(calculateTip: (Double, Double, Boolean) -> String) {
     var amountInput by remember { mutableStateOf("") }
     var tipInput by remember { mutableStateOf("") }
+    var roundUp by remember { mutableStateOf(false) }
 
     // StringからDoubleに型変換
     val amount = amountInput.toDoubleOrNull() ?: 0.0
     val tipPercent = tipInput.toDoubleOrNull() ?: 0.0
     // 計算実行した結果を変数に格納
-    val tip = calculateTip.invoke(amount, tipPercent)
+    val tip = calculateTip.invoke(amount, tipPercent, roundUp)
 
     val focusManager = LocalFocusManager.current
 
@@ -75,6 +81,10 @@ fun TipTimeScreen(calculateTip: (Double, Double) -> String) {
             value = tipInput,
             onValueChange = { tipInput = it }
         )
+        RoundTheTipRow(
+            roundUp = roundUp,
+            onRoundUpChanged = { roundUp = it }
+        )
         Spacer(modifier = Modifier.height(24.dp))
         Text(
             text = stringResource(id = R.string.tip_amount, tip),
@@ -86,7 +96,7 @@ fun TipTimeScreen(calculateTip: (Double, Double) -> String) {
 }
 
 /**
- * チップの計算
+ * チップ入力
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -104,7 +114,7 @@ fun EditNumberField(
         keyboardActions = keyboardActions,
         onValueChange = onValueChange,
         label = { Text(stringResource(label)) },
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         singleLine = true,
     )
 }
@@ -145,6 +155,6 @@ fun RoundTheTipRow(
 @Composable
 fun DefaultPreview() {
     TipTimeTheme {
-        TipTimeScreen { _, _ -> "$15.00" }
+        TipTimeScreen { _, _, _ -> "$15.00" }
     }
 }

--- a/app/src/main/java/com/example/tiptime/TipTimeScreen.kt
+++ b/app/src/main/java/com/example/tiptime/TipTimeScreen.kt
@@ -109,6 +109,38 @@ fun EditNumberField(
     )
 }
 
+/**
+ * 切り上げ表示するかどうか
+ */
+@Composable
+fun RoundTheTipRow(
+    roundUp: Boolean = false,
+    onRoundUpChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .size(48.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = stringResource(id = R.string.round_up_tip),
+            textAlign = TextAlign.Start
+        )
+        Switch(
+            checked = roundUp,
+            onCheckedChange = onRoundUpChanged,
+            modifier = modifier
+                .fillMaxWidth()
+                .wrapContentWidth(align = Alignment.End),
+            colors = SwitchDefaults.colors(
+                uncheckedThumbColor = Color.DarkGray
+            )
+        )
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 fun DefaultPreview() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <string name="app_name">TipTime</string>
     <string name="calculate_tip">Calculate Tip</string>
-    <string name="cost_of_service">Cost of Service</string>
+    <string name="bill_amount">Bill Amount</string>
     <string name="tip_amount">Tip amount: %s</string>
+    <string name="how_was_the_service">Tip (%)</string>
+    <string name="round_up_tip">Round up tip?</string>
 </resources>


### PR DESCRIPTION
## チケットへのリンク

* https://developer.android.com/codelabs/basic-android-kotlin-compose-calculate-tip?hl=ja&continue=https%3A%2F%2Fdeveloper.android.com%2Fcourses%2Fpathways%2Fandroid-basics-compose-unit-2-pathway-3%3Fhl%3Dja%23codelab-https%3A%2F%2Fdeveloper.android.com%2Fcodelabs%2Fbasic-android-kotlin-compose-calculate-tip#8

## 対応内容

* チップパーセンテージを任意の変更できるUIと処理を追加


## レビュー観点

* 切り上げスイッチがtrueの時は計算結果を切り上げ表示できること


## 期待動作

* どのような動作確認を行ったのか？　結果はどうか？

## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/TipTime/assets/82929509/073afbd1-c30d-4a68-8cff-187ba5dec03b" width="200px"/>|<img src="https://github.com/yanPWA/TipTime/assets/82929509/d8edb035-2994-41c0-adec-26328b2acb33" width="200px"/>|




